### PR TITLE
Use Anybotics fork of message logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A copy of the license is available in the *COPYING* file.
 
 | Repo           | url                                                  | license      | content            |
 |:--------------:|:----------------------------------------------------:|:------------:|:------------------:|
-| message_logger | https://github.com/leggedrobotics/message_logger.git | BSD 3-Clause | simple log streams |
+| message_logger | https://github.com/ANYbotics/message_logger          | BSD 3-Clause | simple log streams |
 
 
 	


### PR DESCRIPTION
The issue with the leggedrobotics fork is that it uses C++11 which is not compatible with recent (say, Ubuntu 24.04) versions of the gtest suite. Hence, compiling without modification is not possible. Log example when trying to `colcon build` it:

```
In file included from /usr/src/googletest/googletest/include/gtest/gtest-message.h:57,
                 from /usr/src/googletest/googletest/include/gtest/gtest-assertion-result.h:46,
                 from /usr/src/googletest/googletest/include/gtest/gtest.h:64,
                 from /home/uli/dev/Versatile/message_logger/test/EmptyTests.cpp:1:
/usr/src/googletest/googletest/include/gtest/internal/gtest-port.h:279:2: error: #error C++ versions less than C++14 are not supported.
  279 | #error C++ versions less than C++14 are not supported.
      |  ^~~~~
/usr/src/googletest/googletest/include/gtest/gtest-assertion-result.h: In member function ‘void testing::AssertionResult::AppendMessage(const testing::Message&)’:
/usr/src/googletest/googletest/include/gtest/gtest-assertion-result.h:207:48: error: ‘make_unique’ is not a member of ‘std’
  207 |     if (message_ == nullptr) message_ = ::std::make_unique<::std::string>();
      |                                                ^~~~~~~~~~~
/usr/src/googletest/googletest/include/gtest/gtest-assertion-result.h:207:48: note: ‘std::make_unique’ is only available from C++14 onwards
/usr/src/googletest/googletest/include/gtest/gtest-assertion-result.h:207:73: error: expected primary-expression before ‘>’ token
  207 |     if (message_ == nullptr) message_ = ::std::make_unique<::std::string>();
      |                                                                         ^
/usr/src/googletest/googletest/include/gtest/gtest-assertion-result.h:207:75: error: expected primary-expression before ‘)’ token
  207 |     if (message_ == nullptr) message_ = ::std::make_unique<::std::string>();
      |                                                                           ^
In file included from /usr/src/googletest/googletest/include/gtest/gtest-printers.h:122,
                 from /usr/src/googletest/googletest/include/gtest/gtest-matchers.h:49,
                 from /usr/src/googletest/googletest/include/gtest/internal/gtest-death-test-internal.h:47,
                 from /usr/src/googletest/googletest/include/gtest/gtest-death-test.h:43,
                 from /usr/src/googletest/googletest/include/gtest/gtest.h:65:
/usr/src/googletest/googletest/include/gtest/internal/gtest-internal.h: At global scope:
/usr/src/googletest/googletest/include/gtest/internal/gtest-internal.h:622:58: error: wrong number of template arguments (0, should be 1)
  622 |   typedef ::std::map<std::string, CodeLocation, std::less<>> RegisteredTestsMap;
      |                                                          ^
In file included from /usr/include/c++/13/string:49,
                 from /usr/include/c++/13/bits/locale_classes.h:40,
                 from /usr/include/c++/13/bits/ios_base.h:41,
                 from /usr/include/c++/13/iomanip:42,
                 from /usr/src/googletest/googletest/include/gtest/gtest.h:54:
/usr/include/c++/13/bits/stl_function.h:403:12: note: provided for ‘template<class _Tp> struct std::less’
  403 |     struct less : public binary_function<_Tp, _Tp, bool>
      |            ^~~~
/usr/src/googletest/googletest/include/gtest/internal/gtest-internal.h:622:59: error: template argument 3 is invalid
  622 |   typedef ::std::map<std::string, CodeLocation, std::less<>> RegisteredTestsMap;
      |                                                           ^~
/usr/src/googletest/googletest/include/gtest/internal/gtest-internal.h: In member function ‘bool testing::internal::TypedTestSuitePState::AddTestName(const char*, int, const char*, const char*)’:
/usr/src/googletest/googletest/include/gtest/internal/gtest-internal.h:599:23: error: request for member ‘insert’ in ‘((testing::internal::TypedTestSuitePState*)this)->testing::internal::TypedTestSuitePState::registered_tests_’, which is of non-class type ‘testing::internal::TypedTestSuitePState::RegisteredTestsMap’ {aka ‘int’}
  599 |     registered_tests_.insert(
      |                       ^~~~~~
/usr/src/googletest/googletest/include/gtest/internal/gtest-internal.h: In member function ‘bool testing::internal::TypedTestSuitePState::TestExists(const std::string&) const’:
/usr/src/googletest/googletest/include/gtest/internal/gtest-internal.h:605:30: error: request for member ‘count’ in ‘((const testing::internal::TypedTestSuitePState*)this)->testing::internal::TypedTestSuitePState::registered_tests_’, which is of non-class type ‘const testing::internal::TypedTestSuitePState::RegisteredTestsMap’ {aka ‘const int’}
  605 |     return registered_tests_.count(test_name) > 0;
      |                              ^~~~~
/usr/src/googletest/googletest/include/gtest/internal/gtest-internal.h: In member function ‘const testing::internal::CodeLocation& testing::internal::TypedTestSuitePState::GetCodeLocation(const std::string&) const’:
/usr/src/googletest/googletest/include/gtest/internal/gtest-internal.h:609:40: error: qualified-id in declaration before ‘it’
  609 |     RegisteredTestsMap::const_iterator it = registered_tests_.find(test_name);
      |                                        ^~
/usr/src/googletest/googletest/include/gtest/internal/gtest-internal.h:610:5: error: ‘it’ was not declared in this scope; did you mean ‘int’?
  610 |     GTEST_CHECK_(it != registered_tests_.end());
      |     ^~~~~~~~~~~~
/usr/src/googletest/googletest/include/gtest/internal/gtest-internal.h:610:5: error: request for member ‘end’ in ‘((const testing::internal::TypedTestSuitePState*)this)->testing::internal::TypedTestSuitePState::registered_tests_’, which is of non-class type ‘const testing::internal::TypedTestSuitePState::RegisteredTestsMap’ {aka ‘const int’}
  610 |     GTEST_CHECK_(it != registered_tests_.end());
      |     ^~~~~~~~~~~~
/usr/src/googletest/googletest/include/gtest/internal/gtest-internal.h:611:12: error: ‘it’ was not declared in this scope; did you mean ‘int’?
  611 |     return it->second;
      |            ^~
      |            int
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h: At global scope:
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:725:75: error: wrong number of template arguments (0, should be 1)
  725 | class EqMatcher : public ComparisonBase<EqMatcher<Rhs>, Rhs, std::equal_to<>> {
      |                                                                           ^
/usr/include/c++/13/bits/stl_function.h:373:12: note: provided for ‘template<class _Tp> struct std::equal_to’
  373 |     struct equal_to : public binary_function<_Tp, _Tp, bool>
      |            ^~~~~~~~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:725:76: error: template argument 3 is invalid
  725 | class EqMatcher : public ComparisonBase<EqMatcher<Rhs>, Rhs, std::equal_to<>> {
      |                                                                            ^~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h: In constructor ‘testing::internal::EqMatcher<Rhs>::EqMatcher(const Rhs&)’:
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:728:58: error: wrong number of template arguments (0, should be 1)
  728 |       : ComparisonBase<EqMatcher<Rhs>, Rhs, std::equal_to<>>(rhs) {}
      |                                                          ^
/usr/include/c++/13/bits/stl_function.h:373:12: note: provided for ‘template<class _Tp> struct std::equal_to’
  373 |     struct equal_to : public binary_function<_Tp, _Tp, bool>
      |            ^~~~~~~~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:728:59: error: template argument 3 is invalid
  728 |       : ComparisonBase<EqMatcher<Rhs>, Rhs, std::equal_to<>>(rhs) {}
      |                                                           ^~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:728:61: error: expected ‘{’ before ‘(’ token
  728 |       : ComparisonBase<EqMatcher<Rhs>, Rhs, std::equal_to<>>(rhs) {}
      |                                                             ^
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h: At global scope:
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:734:67: error: wrong number of template arguments (0, should be 1)
  734 |     : public ComparisonBase<NeMatcher<Rhs>, Rhs, std::not_equal_to<>> {
      |                                                                   ^
/usr/include/c++/13/bits/stl_function.h:383:12: note: provided for ‘template<class _Tp> struct std::not_equal_to’
  383 |     struct not_equal_to : public binary_function<_Tp, _Tp, bool>
      |            ^~~~~~~~~~~~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:734:68: error: template argument 3 is invalid
  734 |     : public ComparisonBase<NeMatcher<Rhs>, Rhs, std::not_equal_to<>> {
      |                                                                    ^~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h: In constructor ‘testing::internal::NeMatcher<Rhs>::NeMatcher(const Rhs&)’:
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:737:62: error: wrong number of template arguments (0, should be 1)
  737 |       : ComparisonBase<NeMatcher<Rhs>, Rhs, std::not_equal_to<>>(rhs) {}
      |                                                              ^
/usr/include/c++/13/bits/stl_function.h:383:12: note: provided for ‘template<class _Tp> struct std::not_equal_to’
  383 |     struct not_equal_to : public binary_function<_Tp, _Tp, bool>
      |            ^~~~~~~~~~~~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:737:63: error: template argument 3 is invalid
  737 |       : ComparisonBase<NeMatcher<Rhs>, Rhs, std::not_equal_to<>>(rhs) {}
      |                                                               ^~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:737:65: error: expected ‘{’ before ‘(’ token
  737 |       : ComparisonBase<NeMatcher<Rhs>, Rhs, std::not_equal_to<>>(rhs) {}
      |                                                                 ^
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h: At global scope:
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:742:71: error: wrong number of template arguments (0, should be 1)
  742 | class LtMatcher : public ComparisonBase<LtMatcher<Rhs>, Rhs, std::less<>> {
      |                                                                       ^
/usr/include/c++/13/bits/stl_function.h:403:12: note: provided for ‘template<class _Tp> struct std::less’
  403 |     struct less : public binary_function<_Tp, _Tp, bool>
      |            ^~~~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:742:72: error: template argument 3 is invalid
  742 | class LtMatcher : public ComparisonBase<LtMatcher<Rhs>, Rhs, std::less<>> {
      |                                                                        ^~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h: In constructor ‘testing::internal::LtMatcher<Rhs>::LtMatcher(const Rhs&)’:
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:745:54: error: wrong number of template arguments (0, should be 1)
  745 |       : ComparisonBase<LtMatcher<Rhs>, Rhs, std::less<>>(rhs) {}
      |                                                      ^
/usr/include/c++/13/bits/stl_function.h:403:12: note: provided for ‘template<class _Tp> struct std::less’
  403 |     struct less : public binary_function<_Tp, _Tp, bool>
      |            ^~~~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:745:55: error: template argument 3 is invalid
  745 |       : ComparisonBase<LtMatcher<Rhs>, Rhs, std::less<>>(rhs) {}
      |                                                       ^~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:745:57: error: expected ‘{’ before ‘(’ token
  745 |       : ComparisonBase<LtMatcher<Rhs>, Rhs, std::less<>>(rhs) {}
      |                                                         ^
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h: At global scope:
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:750:74: error: wrong number of template arguments (0, should be 1)
  750 | class GtMatcher : public ComparisonBase<GtMatcher<Rhs>, Rhs, std::greater<>> {
      |                                                                          ^
/usr/include/c++/13/bits/stl_function.h:393:12: note: provided for ‘template<class _Tp> struct std::greater’
  393 |     struct greater : public binary_function<_Tp, _Tp, bool>
      |            ^~~~~~~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:750:75: error: template argument 3 is invalid
  750 | class GtMatcher : public ComparisonBase<GtMatcher<Rhs>, Rhs, std::greater<>> {
      |                                                                           ^~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h: In constructor ‘testing::internal::GtMatcher<Rhs>::GtMatcher(const Rhs&)’:
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:753:57: error: wrong number of template arguments (0, should be 1)
  753 |       : ComparisonBase<GtMatcher<Rhs>, Rhs, std::greater<>>(rhs) {}
      |                                                         ^
/usr/include/c++/13/bits/stl_function.h:393:12: note: provided for ‘template<class _Tp> struct std::greater’
  393 |     struct greater : public binary_function<_Tp, _Tp, bool>
      |            ^~~~~~~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:753:58: error: template argument 3 is invalid
  753 |       : ComparisonBase<GtMatcher<Rhs>, Rhs, std::greater<>>(rhs) {}
      |                                                          ^~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:753:60: error: expected ‘{’ before ‘(’ token
  753 |       : ComparisonBase<GtMatcher<Rhs>, Rhs, std::greater<>>(rhs) {}
      |                                                            ^
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h: At global scope:
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:759:65: error: wrong number of template arguments (0, should be 1)
  759 |     : public ComparisonBase<LeMatcher<Rhs>, Rhs, std::less_equal<>> {
      |                                                                 ^
/usr/include/c++/13/bits/stl_function.h:423:12: note: provided for ‘template<class _Tp> struct std::less_equal’
  423 |     struct less_equal : public binary_function<_Tp, _Tp, bool>
      |            ^~~~~~~~~~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:759:66: error: template argument 3 is invalid
  759 |     : public ComparisonBase<LeMatcher<Rhs>, Rhs, std::less_equal<>> {
      |                                                                  ^~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h: In constructor ‘testing::internal::LeMatcher<Rhs>::LeMatcher(const Rhs&)’:
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:762:60: error: wrong number of template arguments (0, should be 1)
  762 |       : ComparisonBase<LeMatcher<Rhs>, Rhs, std::less_equal<>>(rhs) {}
      |                                                            ^
/usr/include/c++/13/bits/stl_function.h:423:12: note: provided for ‘template<class _Tp> struct std::less_equal’
  423 |     struct less_equal : public binary_function<_Tp, _Tp, bool>
      |            ^~~~~~~~~~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:762:61: error: template argument 3 is invalid
  762 |       : ComparisonBase<LeMatcher<Rhs>, Rhs, std::less_equal<>>(rhs) {}
      |                                                             ^~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:762:63: error: expected ‘{’ before ‘(’ token
  762 |       : ComparisonBase<LeMatcher<Rhs>, Rhs, std::less_equal<>>(rhs) {}
      |                                                               ^
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h: At global scope:
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:768:68: error: wrong number of template arguments (0, should be 1)
  768 |     : public ComparisonBase<GeMatcher<Rhs>, Rhs, std::greater_equal<>> {
      |                                                                    ^
/usr/include/c++/13/bits/stl_function.h:413:12: note: provided for ‘template<class _Tp> struct std::greater_equal’
  413 |     struct greater_equal : public binary_function<_Tp, _Tp, bool>
      |            ^~~~~~~~~~~~~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:768:69: error: template argument 3 is invalid
  768 |     : public ComparisonBase<GeMatcher<Rhs>, Rhs, std::greater_equal<>> {
      |                                                                     ^~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h: In constructor ‘testing::internal::GeMatcher<Rhs>::GeMatcher(const Rhs&)’:
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:771:63: error: wrong number of template arguments (0, should be 1)
  771 |       : ComparisonBase<GeMatcher<Rhs>, Rhs, std::greater_equal<>>(rhs) {}
      |                                                               ^
/usr/include/c++/13/bits/stl_function.h:413:12: note: provided for ‘template<class _Tp> struct std::greater_equal’
  413 |     struct greater_equal : public binary_function<_Tp, _Tp, bool>
      |            ^~~~~~~~~~~~~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:771:64: error: template argument 3 is invalid
  771 |       : ComparisonBase<GeMatcher<Rhs>, Rhs, std::greater_equal<>>(rhs) {}
      |                                                                ^~
/usr/src/googletest/googletest/include/gtest/gtest-matchers.h:771:66: error: expected ‘{’ before ‘(’ token
  771 |       : ComparisonBase<GeMatcher<Rhs>, Rhs, std::greater_equal<>>(rhs) {}
      |                                                                  ^
/usr/src/googletest/googletest/include/gtest/gtest.h: At global scope:
/usr/src/googletest/googletest/include/gtest/gtest.h:302:30: error: ‘std::enable_if_t’ has not been declared
  302 |   template <typename T, std::enable_if_t<std::is_convertible<T, int64_t>::value,
      |                              ^~~~~~~~~~~
/usr/src/googletest/googletest/include/gtest/gtest.h:302:41: error: expected ‘>’ before ‘<’ token
  302 |   template <typename T, std::enable_if_t<std::is_convertible<T, int64_t>::value,
      |                                         ^
gmake[3]: *** [CMakeFiles/test_message_logger.dir/build.make:76: CMakeFiles/test_message_logger.dir/test/EmptyTests.cpp.o] Error 1
gmake[2]: *** [CMakeFiles/Makefile2:331: CMakeFiles/test_message_logger.dir/all] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:180: CMakeFiles/tests.dir/rule] Error 2
gmake: *** [Makefile:192: tests] Error 2
---
Failed   <<< message_logger [6.12s, exited with code 2]
                                
Summary: 0 packages finished [6.20s]
  1 package failed: message_logger
  1 package had stderr output: message_logger
```