### PR TITLE
feat(ci): update CI workflows

### DIFF
--- a/.github/workflows/build-humble.yml
+++ b/.github/workflows/build-humble.yml
@@ -8,8 +8,9 @@ on:
     branches:
       - master
   schedule:
-    # Run every morning to detect flakiness and broken dependencies
-    - cron: '13 4 * * *'
+    # Run every morning at 01:00 to detect flakiness and broken dependencies
+    - cron: '0 1 * * *'
+      timezone: "Europe/Zurich"
 
 jobs:
   humble_binary_main:

--- a/.github/workflows/build-jazzy.yml
+++ b/.github/workflows/build-jazzy.yml
@@ -8,8 +8,9 @@ on:
     branches:
       - master
   schedule:
-    # Run every morning to detect flakiness and broken dependencies
-    - cron: '13 4 * * *'
+    # Run every morning at 01:00 to detect flakiness and broken dependencies
+    - cron: '0 1 * * *'
+      timezone: "Europe/Zurich"
 
 jobs:
   jazzy_binary_main:

--- a/.github/workflows/build-kilted.yml
+++ b/.github/workflows/build-kilted.yml
@@ -8,8 +8,9 @@ on:
     branches:
       - master
   schedule:
-    # Run every morning to detect flakiness and broken dependencies
-    - cron: '13 4 * * *'
+    # Run every morning at 01:00 to detect flakiness and broken dependencies
+    - cron: '0 1 * * *'
+      timezone: "Europe/Zurich"
 
 jobs:
   kilted_binary_main:

--- a/.github/workflows/build-lyrical.yml
+++ b/.github/workflows/build-lyrical.yml
@@ -8,8 +8,9 @@ on:
     branches:
       - master
   schedule:
-    # Run every morning to detect flakiness and broken dependencies
-    - cron: '13 4 * * *'
+    # Run every morning at 01:00 to detect flakiness and broken dependencies
+    - cron: '0 1 * * *'
+      timezone: "Europe/Zurich"
 
 jobs:
   lyrical_binary_master:

--- a/.github/workflows/build-rolling.yml
+++ b/.github/workflows/build-rolling.yml
@@ -8,8 +8,9 @@ on:
     branches:
       - master
   schedule:
-    # Run every morning to detect flakiness and broken dependencies
-    - cron: '13 4 * * *'
+    # Run every morning at 01:00 to detect flakiness and broken dependencies
+    - cron: '0 1 * * *'
+      timezone: "Europe/Zurich"
 
 jobs:
   rolling_binary_main:

--- a/.github/workflows/reusable_ici.yml
+++ b/.github/workflows/reusable_ici.yml
@@ -4,6 +4,11 @@ name: Reusable industrial_ci workflow
 on:
   workflow_call:
     inputs:
+      timeout_minutes:
+        description: 'Maximum time the job is allowed to run.'
+        default: 30
+        required: false
+        type: number
       ref_for_scheduled_build:
         description: 'Reference on which the repo should be checkout for scheduled build. Usually is this name of a branch or a tag.'
         default: ''
@@ -42,6 +47,7 @@ on:
 jobs:
   reusable_ici:
     name: ${{ inputs.ros_distro }} ${{ inputs.ros_repo }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     runs-on: ${{ inputs.image }}
     env:
       CCACHE_DIR: ${{ github.workspace }}/${{ inputs.ccache_dir }}


### PR DESCRIPTION
Bring CI workflows in line with the standard setup:
- add configurable job timeout_minutes (default 30) to reusable_ici
- run scheduled daily builds at 01:00 Europe/Zurich
- build rolling against the testing apt repo